### PR TITLE
prepareForGet() does not always work in getDefaultDevice(). 

### DIFF
--- a/nest.class.php
+++ b/nest.class.php
@@ -352,7 +352,7 @@ class Nest {
     }
 
     public function getDefaultDevice() {
-        $this->prepareForGet();
+        $this->getStatus();
         $structure = $this->last_status->user->{$this->userid}->structures[0];
         list(, $structure_id) = explode('.', $structure);
         $device = $this->last_status->structure->{$structure_id}->devices[0];


### PR DESCRIPTION
Similar to getDeviceNetworkInfo and other functions, had to call prepareForGet() instead of prepareForGet() for default device to return data. Tested with Nest v2 Only.
