### PR TITLE
Added two new functions

### DIFF
--- a/nest.class.php
+++ b/nest.class.php
@@ -362,7 +362,7 @@ class Nest {
     }
 
     public function getDeviceFriendlyName($serial_number=NULL) {
-        $this->getStatus();
+        $serial_number = $this->getDefaultSerial($serial_number);
         $name = !empty($this->last_status->shared->{$serial_number}->name) ? $this->last_status->shared->{$serial_number}->name : DEVICE_WITH_NO_NAME;
         return $name;
     }


### PR DESCRIPTION
getDeviceFriendlyName
Argument: Serial Number
Returns the device's friendly name if set, else returns DEVICE_WITH_NO_NAME

getDevices() - Useful in multi-device scenarios. Returns an array of serials found.
