### PR TITLE
use_cache function will always return false

### DIFF
--- a/nest.class.php
+++ b/nest.class.php
@@ -90,10 +90,11 @@ class Nest {
         static::secure_touch($this->cookie_file);
 
         $this->cache_file = sys_get_temp_dir() . '/nest_php_cache_' . md5($username . $password);
+        if (file_exists($this->cache_file)) {
+             $this->loadCache();
+         }        
         static::secure_touch($this->cache_file);
-        if ($this->use_cache()) {
-            $this->loadCache();
-        }
+        
         // Log in, if needed
         $this->login();
     }


### PR DESCRIPTION
Load the cache in the constructor if a cache file already exists otherwise $this->cache_expiration is never set.
