### PR TITLE
Fix problem where access tokens are requested everytime script is run

### DIFF
--- a/nest.class.php
+++ b/nest.class.php
@@ -580,7 +580,7 @@ class Nest {
     }
 
     private function use_cache() {
-        return file_exists($this->cookie_file) && file_exists($this->cache_file) && !empty($this->cache_expiration) && $this->cache_expiration > time();
+        return file_exists($this->cookie_file) && file_exists($this->cache_file) && (empty($this->cache_expiration) || $this->cache_expiration > time());
     }
     
     private function loadCache() {


### PR DESCRIPTION
I found that every time my script runs which uses this API the API generated a new access token which caused problems with my phone app always losing its token.

The reason appears to be that use_cache returns false when the cache hasn't yet been loaded so it never loads the cache from the previous attempt :) I think this change fixes it.
