### PR TITLE
Site is forcing HTTPS now. Reflecting that in code.

### DIFF
--- a/nest.class.php
+++ b/nest.class.php
@@ -701,7 +701,7 @@ class Nest {
         $curl_cainfo = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cacert.pem';
         $last_month = time()-30*24*60*60;
         if (!file_exists($curl_cainfo) || filemtime($curl_cainfo) < $last_month || filesize($curl_cainfo) < 100000) {
-            file_put_contents($curl_cainfo, file_get_contents('http://curl.haxx.se/ca/cacert.pem'));
+            file_put_contents($curl_cainfo, file_get_contents('https://curl.haxx.se/ca/cacert.pem'));
         }
         if (file_exists($curl_cainfo) && filesize($curl_cainfo) > 100000) {
             curl_setopt($ch, CURLOPT_CAINFO, $curl_cainfo);


### PR DESCRIPTION
Ran into an issue with the site redirecting to HTTPS and not having the `extension=php_openssl.dll` loaded in my PHP environment. Loading the extension fixes the problem so this change isn't required, but makes it explicit as to what is happening.