### PR TITLE
Update nest.class.php to add Heating/Cooling Active Stages & Eco Temp…

### DIFF
--- a/nest.class.php
+++ b/nest.class.php
@@ -294,6 +294,26 @@ class Nest {
                 'manual_away' => $manual_away,
                 'leaf' => $this->last_status->device->{$serial_number}->leaf,
                 'battery_level' => $this->last_status->device->{$serial_number}->battery_level,
+                'active_stages' => (object) array(
+                    'heat' => (object) array(
+                        'stage1' => $this->last_status->shared->{$serial_number}->hvac_heater_state,
+                        'stage2' => $this->last_status->shared->{$serial_number}->hvac_heat_x2_state,
+                        'stage3' => $this->last_status->shared->{$serial_number}->hvac_heat_x3_state,
+                        'alt' => $this->last_status->shared->{$serial_number}->hvac_alt_heat_state,
+                        'alt_stage2' => $this->last_status->shared->{$serial_number}->hvac_alt_heat_x2_state,
+                        'aux' => $this->last_status->shared->{$serial_number}->hvac_aux_heater_state,
+                        'emergency' => $this->last_status->shared->{$serial_number}->hvac_emer_heat_state,
+                    ),
+                    'cool' => (object) array(
+                        'stage1' => $this->last_status->shared->{$serial_number}->hvac_ac_state,
+                        'stage2' => $this->last_status->shared->{$serial_number}->hvac_cool_x2_state,
+                        'stage3' => $this->last_status->shared->{$serial_number}->hvac_cool_x3_state,
+                    ),
+                ),
+                'eco_temperatures' => (object)array(
+                    'low' => ($this->last_status->device->{$serial_number}->away_temperature_low_enabled) ? $this->temperatureInUserScale((float)$this->last_status->device->{$serial_number}->away_temperature_low) : false,
+                    'high' => ($this->last_status->device->{$serial_number}->away_temperature_high_enabled) ? $this->temperatureInUserScale((float)$this->last_status->device->{$serial_number}->away_temperature_high) : false,
+                ),
             ),
             'target' => (object) array(
                 'mode' => $target_mode,


### PR DESCRIPTION
…eratures

Current heat and ac state only indicate if it's actively cooling/heating (left them for legacy). I've broken it out into each stage so you can tell which stages are active. In testing (2 stage heat / 1 stage cool) it seems that the best bet is to start at the highest stage you have and work your way backwards to see which stage you're in. It seems the lower stages do seem to indicate they're on even if it's at a higher stage.  (e.g. check  stage 3, then check stage 2, then check stage 1);

Eco/Away temperatures - Had a need to know what my requested ECO Temperatures are. Indicates false if not currently enabled.