### PR TITLE
protected over private / logic change in getDeviceInfo

### DIFF
--- a/nest.class.php
+++ b/nest.class.php
@@ -44,9 +44,9 @@ class Nest {
     const user_agent = 'Nest/2.1.3 CFNetwork/548.0.4';
     const protocol_version = 1;
     const login_url = 'https://home.nest.com/user/login';
-    private $days_maps = array('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun');
+    protected $days_maps = array('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun');
 
-    private $where_map = array(
+    protected $where_map = array(
         '00000000-0000-0000-0000-000100000000' => 'Entryway',
         '00000000-0000-0000-0000-000100000001' => 'Basement',
         '00000000-0000-0000-0000-000100000002' => 'Hallway',
@@ -66,14 +66,14 @@ class Nest {
         '00000000-0000-0000-0000-000100000010' => 'Dining Room',
     );
     
-    private $transport_url;
-    private $access_token;
-    private $user;
-    private $userid;
-    private $cookie_file;
-    private $cache_file;
-    private $cache_expiration;
-    private $last_status;
+    protected $transport_url;
+    protected $access_token;
+    protected $user;
+    protected $userid;
+    protected $cookie_file;
+    protected $cache_file;
+    protected $cache_expiration;
+    protected $last_status;
     
     function __construct($username=null, $password=null) {
         if ($username === null && defined('USERNAME')) {
@@ -268,23 +268,56 @@ class Nest {
         }
 
         list(, $structure) = explode('.', $this->last_status->link->{$serial_number}->structure);
-        $manual_away = $this->last_status->structure->{$structure}->away;
+        $currentModeWithAttributes = array();
+        $structure_away = $this->last_status->structure->{$structure}->away;
         $mode = strtolower($this->last_status->device->{$serial_number}->current_schedule_mode);
         $target_mode = $this->last_status->shared->{$serial_number}->target_temperature_type;
-        $eco_mode = $this->last_status->device->{$serial_number}->eco->mode;	//manual-eco, auto-eco, schedule
-        if ($manual_away || $mode == 'away' || $this->last_status->shared->{$serial_number}->auto_away > 0) {
-            $mode = $mode . ',away';
-            $target_mode = 'range';
-            $target_temperatures = array($this->temperatureInUserScale((float) $this->last_status->device->{$serial_number}->away_temperature_low), $this->temperatureInUserScale((float) $this->last_status->device->{$serial_number}->away_temperature_high));
-        } else if ($mode == 'range') {
-            $target_mode = 'range';
+        $eco_mode = $this->last_status->device->{$serial_number}->eco->mode;    //manual-eco, auto-eco, schedule
+
+        if($target_mode == TARGET_TEMP_MODE_OFF){
+            $target_temperatures = false; //No target due to it being off
+            $mode = TARGET_TEMP_MODE_OFF;                 
+        }       
+        else if ($eco_mode !== "schedule"){
+                //We are in eco, thus not actively using the schedule -  add as additional attribute
+                array_push($currentModeWithAttributes,$eco_mode);
+                //Check if we have both low and high temp eco temperatures
+                if($this->last_status->device->{$serial_number}->away_temperature_low_enabled && $this->last_status->device->{$serial_number}->away_temperature_high_enabled){
+                    $mode = TARGET_TEMP_MODE_RANGE;
+                    $target_temperatures = array($this->temperatureInUserScale((float) $this->last_status->device->{$serial_number}->away_temperature_low), 
+                        $this->temperatureInUserScale((float) $this->last_status->device->{$serial_number}->away_temperature_high));
+                }
+                //Check to see if we have only an eco temp low
+                else if($this->last_status->device->{$serial_number}->away_temperature_low_enabled){
+                    $mode = TARGET_TEMP_MODE_HEAT; //we only have eco low turned on - so we're only in heat
+                    $target_temperatures = $this->temperatureInUserScale((float) $this->last_status->device->{$serial_number}->away_temperature_low);
+                }
+                //Check to see if we have only an eco temp high
+                else if($this->last_status->device->{$serial_number}->away_temperature_high_enabled){
+                    $mode = TARGET_TEMP_MODE_COOL; //we only have eco high turned on - so we're only in cool
+                    $target_temperatures = $this->temperatureInUserScale((float) $this->last_status->device->{$serial_number}->away_temperature_high);
+                }
+                //we're in eco with no away temperatures set
+                else{
+                    $mode = TARGET_TEMP_MODE_OFF; //we have no eco temperatures turned on - so we're technically off (safety temps would still kick in)
+                    $target_temperatures = false;
+                }
+        }
+        else if($target_mode === 'range'){
             $target_temperatures = array($this->temperatureInUserScale((float) $this->last_status->shared->{$serial_number}->target_temperature_low), $this->temperatureInUserScale((float) $this->last_status->shared->{$serial_number}->target_temperature_high));
-        } else {
+        } else {               
+            //it is either heat or cool mode
             $target_temperatures = $this->temperatureInUserScale((float) $this->last_status->shared->{$serial_number}->target_temperature);
         }
+
+        //Add away if structure is away
+        if($structure_away){ array_push($currentModeWithAttributes,"away"); }  
+        //Add the mode to first in array
+        array_unshift($currentModeWithAttributes,$mode);
+
         $infos = (object) array(
             'current_state' => (object) array(
-                'mode' => $mode,
+                'mode' => implode(',',$currentModeWithAttributes),
                 'temperature' => $this->temperatureInUserScale((float) $this->last_status->shared->{$serial_number}->current_temperature),
                 'humidity' => $this->last_status->device->{$serial_number}->current_humidity,
                 'ac' => $this->last_status->shared->{$serial_number}->hvac_ac_state,
@@ -292,7 +325,8 @@ class Nest {
                 'alt_heat' => $this->last_status->shared->{$serial_number}->hvac_alt_heat_state,
                 'fan' => $this->last_status->shared->{$serial_number}->hvac_fan_state,
                 'auto_away' => $this->last_status->shared->{$serial_number}->auto_away, // -1 when disabled, 0 when enabled (thermostat can set auto-away), >0 when enabled and active (thermostat is currently in auto-away mode)
-                'manual_away' => $manual_away,
+                'manual_away' => $structure_away, //Leaving this for others - but manual away really doesn't exist anymore and should be removed eventually
+                'structure_away' => $structure_away,
                 'leaf' => $this->last_status->device->{$serial_number}->leaf,
                 'battery_level' => $this->last_status->device->{$serial_number}->battery_level,
                 'active_stages' => (object) array(
@@ -598,7 +632,7 @@ class Nest {
         return $devices_serials;
     }
 
-    private function getDefaultSerial($serial_number) {
+    protected function getDefaultSerial($serial_number) {
         if (empty($serial_number)) {
             $devices_serials = $this->getDevices();
             if (count($devices_serials) == 0) {
@@ -614,7 +648,7 @@ class Nest {
         return $this->last_status->device->{$serial_number};
     }
 
-    private function getDeviceNetworkInfo($serial_number=null) {
+    protected function getDeviceNetworkInfo($serial_number=null) {
         $this->prepareForGet();
         $serial_number = $this->getDefaultSerial($serial_number);
         $connection_info = $this->last_status->track->{$serial_number};
@@ -628,7 +662,7 @@ class Nest {
         );
     }
 
-    private function _setFanMode($mode, $fan_duty_cycle=null, $timer=null, $serial_number=null) {
+    protected function _setFanMode($mode, $fan_duty_cycle=null, $timer=null, $serial_number=null) {
         $serial_number = $this->getDefaultSerial($serial_number);
         $data = array();
         if (!empty($mode)) {
@@ -644,13 +678,13 @@ class Nest {
         return $this->doPOST("/v2/put/device." . $serial_number, json_encode($data));
     }
 
-    private function prepareForGet() {
+    protected function prepareForGet() {
         if (!isset($this->last_status)) {
             $this->getStatus();
         }
     }
 
-    private function login() {
+    protected function login() {
         if ($this->use_cache()) {
             // No need to login; we'll use cached values for authentication.
             return;
@@ -667,11 +701,11 @@ class Nest {
         $this->saveCache();
     }
 
-    private function use_cache() {
+    protected function use_cache() {
         return file_exists($this->cookie_file) && file_exists($this->cache_file) && !empty($this->cache_expiration) && $this->cache_expiration > time();
     }
     
-    private function loadCache() {
+    protected function loadCache() {
         if (!file_exists($this->cache_file)) {
             return;
         }
@@ -688,7 +722,7 @@ class Nest {
         // $this->last_status = $vars['last_status'];
     }
     
-    private function saveCache() {
+    protected function saveCache() {
         $vars = array(
             'transport_url' => $this->transport_url,
             'access_token' => $this->access_token,
@@ -700,15 +734,15 @@ class Nest {
         file_put_contents($this->cache_file, serialize($vars));
     }
 
-    private function doGET($url) {
+    protected function doGET($url) {
         return $this->doRequest('GET', $url);
     }
     
-    private function doPOST($url, $data_fields) {
+    protected function doPOST($url, $data_fields) {
         return $this->doRequest('POST', $url, $data_fields);
     }
 
-    private function doRequest($method, $url, $data_fields=null, $with_retry=TRUE) {
+    protected function doRequest($method, $url, $data_fields=null, $with_retry=TRUE) {
         $ch = curl_init();
         if ($url[0] == '/') {
             $url = $this->transport_url . $url;
@@ -800,7 +834,7 @@ class Nest {
         return $json;
     }
     
-    private static function get_curl_certs() {
+    protected static function get_curl_certs() {
         $url = 'https://curl.haxx.se/ca/cacert.pem';
         $certs = @file_get_contents($url);
         if (!$certs) {
@@ -819,7 +853,7 @@ class Nest {
         return $certs;
     }
 
-    private static function secure_touch($fname) {
+    protected static function secure_touch($fname) {
         if (file_exists($fname)) {
             return;
         }


### PR DESCRIPTION
Replaced all instances of private with protected. This will allow others to extend the Nest class into subclasses where functionality may not be for the good of the group, but for their own private use.

With the implementation of Auto / Manual Eco Mode versus Auto/Manual Away the logic for what the thermostat is actually doing has changed. My new logic accounts for scenarios where the structure is still away - but the house has already switched itself back to schedule.  Manual_away really shouldn't be used anymore because it doesn't exist as an option. Although, you can change the structure to away via app/web manual - it should no longer be referred to as "manual away" as it doesn't actually trigger going into manual-eco, but rather forces thermostat into auto-eco and is more for testing mode of cameras.