### PR TITLE
Add ability to specify ISSUE_TOKEN & COOKIES as ENVs

### DIFF
--- a/nest.class.php
+++ b/nest.class.php
@@ -82,6 +82,12 @@ class Nest
      * @throws InvalidArgumentException|UnexpectedValueException|RuntimeException
      */
     public function __construct($username = NULL, $password = NULL, $issue_token = NULL, $cookies = NULL) {
+        if ($issue_token === NULL && defined('ISSUE_TOKEN')) {
+            $issue_token = ISSUE_TOKEN;
+        }
+        if ($cookies === NULL && defined('COOKIES')) {
+            $cookies = COOKIES;
+        }
         if (!empty($issue_token)) {
             $this->issue_token = $issue_token;
             if (empty($cookies)) {


### PR DESCRIPTION
This PR replicates the functionality of being able to specify values for `USERNAME` and `PASSWORD` via ENV variables.  This PR will allow the specification of `ISSUE_TOKEN` and `COOKIES` with ENVs.