### PR TITLE
Add invoke_timestamp to device schedule

### DIFF
--- a/nest.class.php
+++ b/nest.class.php
@@ -226,6 +226,7 @@ class Nest
      * @return array Returns as array, one element for each day of the week for which there has at least one scheduled event.
      *               Array keys are a textual representation of a day, three letters, as returned by `date('D')`.
      *               Array values are arrays of scheduled temperatures, including a time (in minutes after midnight),
+     *               invoke_timestamp of when the event would be activated,
      *               and a mode (one of the TARGET_TEMP_MODE_* defines).
      */
     public function getDeviceSchedule($serial_number = NULL) {
@@ -238,8 +239,10 @@ class Nest
             $events = array();
             foreach ($scheduled_events as $scheduled_event) {
                 if ($scheduled_event->entry_type == 'setpoint') {
+                    $invoke_at = strtotime("{$this->days_maps[(int) $day]} 0:00:00") + $scheduled_event->time;
                     $events[(int)$scheduled_event->time] = (object) array(
                         'time' => $scheduled_event->time/60, // in minutes
+                        'invoke_timestamp' => ($invoke_at >= time()) ? $invoke_at : strtotime("+7 days", $invoked_at),
                         'target_temperature' => $scheduled_event->type == 'RANGE' ? array($this->temperatureInUserScale((float)$scheduled_event->{'temp-min'}), $this->temperatureInUserScale((float)$scheduled_event->{'temp-max'})) : $this->temperatureInUserScale((float) $scheduled_event->temp),
                         'mode' => $scheduled_event->type == 'HEAT' ? TARGET_TEMP_MODE_HEAT : ($scheduled_event->type == 'COOL' ? TARGET_TEMP_MODE_COOL : TARGET_TEMP_MODE_RANGE)
                     );


### PR DESCRIPTION
Adding the parameter to support user implemented logic after use of the getNextScheduledEvent function without needing to replicate or override the function.  Includes support for past scheduled events of "today" to prevent next from being a past timestamp.

**Example:** If today was Monday at 0800 with a device that has scheduled event on Friday 0900, the object returned indicates that the next scheduled event time is at 32400, but it's not immediately able to determine if that event is in 1 hour or days away.